### PR TITLE
Fix stream_info dataset fn

### DIFF
--- a/emloop/datasets/base_dataset.py
+++ b/emloop/datasets/base_dataset.py
@@ -58,9 +58,9 @@ class BaseDataset(AbstractDataset, metaclass=ABCMeta):
             try:
                 stream_fn = getattr(self, stream_name)
                 logging.info(stream_name)
-                batch = next(iter(stream_fn()))
-                rows = []
-                for key, value in batch.items():
+                for batch in stream_fn():
+                    rows = []
+                    for key, value in batch.items():
                         try:
                             value_arr = np.array(value)
                             row = [key, value_arr.dtype, value_arr.shape]
@@ -77,9 +77,10 @@ class BaseDataset(AbstractDataset, metaclass=ABCMeta):
                             logging.warning('*** stream source `%s` appears to be ragged (non-rectangular) ***', key)
 
                         rows.append(row)
-                for line in tabulate.tabulate(rows, headers=['name', 'dtype', 'shape', 'range'],
-                                              tablefmt='grid').split('\n'):
-                    logging.info(line)
+                    for line in tabulate.tabulate(rows, headers=['name', 'dtype', 'shape', 'range'],
+                                                  tablefmt='grid').split('\n'):
+                        logging.info(line)
+                    break
             except Exception:
                 logging.warning('Exception was raised during checking stream `%s`, '
                                 '(stack trace is displayed only with --verbose flag)', stream_name)

--- a/emloop/tests/datasets/base_dataset_test.py
+++ b/emloop/tests/datasets/base_dataset_test.py
@@ -90,7 +90,7 @@ def test_check_dataset(caplog):
         + (('root', logging.DEBUG, 'Traceback (most recent call last):\n'
            f'  File "{emloop.datasets.base_dataset.__file__}", line 61, in '
             'stream_info\n'
-            '    batch = next(iter(stream_fn()))\n'
+            '    for batch in stream_fn():\n'
             "TypeError: 'NoneType' object is not iterable\n"),)
     )
 


### PR DESCRIPTION
Most likely, the following line
```python
batch = next(iter(stream_fn()))
```
caused issues as the stream iterator could have been destroyed too soon (with some C++ datasets it thrown *Corrupted double-linked list* error. Anyways this fixes it.